### PR TITLE
Add error handeling to make filtering functions not case sensitive

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -32,7 +32,6 @@ fetchData().then(responses => {
     recipeRepository.listRecipes();
     user = createUser();
 
-    
     displayRecipeList();
 
 });
@@ -177,7 +176,7 @@ function showRecipeInstructions(event) {
 function filterRecipeTag(event) {
     event.preventDefault();
 
-    const inputValue = recipeTagInput.value;
+    const inputValue = recipeTagInput.value.toLowerCase();
     const requestedRecipes = recipeRepository.findRecipeByTag(inputValue);
 
     recipeHeading.innerText = 'Filtered Recipes by Tag';
@@ -201,7 +200,19 @@ function filterRecipeTag(event) {
 function searchRecipeName(event) {
     event.preventDefault();
 
-    const inputValue = recipeNameInput.value;
+    const inputValue = recipeNameInput.value.split(' ').map(word => {
+    return word.split('').map((letter, index) => {
+        if (!index) {
+            letter = letter.toUpperCase()
+        } else {
+            letter = letter.toLowerCase()
+        }
+
+        return letter
+    }).join('');
+    
+   }).join(' ');
+
     const requestedRecipes = recipeRepository.findRecipeByName(inputValue);
 
     recipeHeading.innerText = 'Filtered Recipes by Name';
@@ -225,7 +236,7 @@ function searchRecipeName(event) {
  function filterFavoriteRecipesByTag(event) {
     event.preventDefault();
 
-    const inputValue = recipeFavoriteTagInput.value;
+    const inputValue = recipeFavoriteTagInput.value.toLowerCase();
     const requestedRecipes = user.filterRecipesToCookByTag(inputValue);
 
     recipeHeading.innerText = 'Filtered Favorite Recipes by Tag';
@@ -248,7 +259,19 @@ function searchRecipeName(event) {
  function searchFavRecipeListByName(event) {
    event.preventDefault();
 
-   const inputValue = recipeFavNameInput.value;
+   const inputValue = recipeFavNameInput.value.split(' ').map(word => {
+    return word.split('').map((letter, index) => {
+        if (!index) {
+            letter = letter.toUpperCase()
+        } else {
+            letter = letter.toLowerCase()
+        }
+
+        return letter
+    }).join('');
+    
+   }).join(' ');
+   
    const requestedRecipes = user.filterRecipesToCookByName(inputValue);
 
    recipeHeading.innerText = 'Filtered Favorite Recipes by Name';

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,7 +11,7 @@ body {
   flex-direction: column;
   align-items: center;
   width: 100vw;
-  height: 18vh;
+  height: 200px;
 }
 
 .heading {


### PR DESCRIPTION
This PR adds error handling to all four functions that search tags/names. 

Changes start at line 176 in the index.js

pull changes, run `git switch feature/Refactore-Anna`, run `npm start`, then go to `http://localhost:8080/` in the browser. Test the filter functions and be sure they aren't buggy. Use random casing to test functions.

The filtering was case sensitive and this PR fixes that.

This solves ticket: 
[UI: Filtering is case sensitive - this can be confusing and make it seem like the filter is not working. For Part 2, make the filter not case sensitive.](https://github.com/AnaBennett11/whats-cookin-group-project/issues/31)